### PR TITLE
Fix build on different python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,16 +2,16 @@
 name = ffmpeg-benchmark
 version = attr: ffmpeg_benchmark.__version__
 author = Anthony Monthe
-author-email = anthony@cloud-mercato.com
+author_email = anthony@cloud-mercato.com
 url = https://github.com/cloudmercato/ffmpeg-benchmark
-project_urls = 
-summary = Handy tool for evaluate ffmpeg performance
-description-file = file: README.rst
+project_urls =
+summary = Handy tool for evaluating ffmpeg performance
+description_file = file: README.rst
 long_description = file: README.rst
-description-content-type = text/x-rst; charset=UTF-8
+description_content_type = text/x-rst; charset=UTF-8
 license = MIT
 
-requires-dist =
+requires_dist =
     setuptools
 
 classifier =
@@ -35,11 +35,14 @@ keywords = benchmark, machine learning, deep learning
 [options]
 zip_safe = False
 include_package_data = True
-package_dir=
-packages=find:
-    
+package_dir =
+packages = find:
+
 install_requires =
-  https://github.com/cloudmercato/handystats/archive/refs/heads/main.zip
+    setuptools
+
+dependency_links =
+    git+https://github.com/cloudmercato/handystats.git#egg=handystats
 
 test_suite = ffmpeg_benchmark.tests
 tests_require =
@@ -57,6 +60,11 @@ omit = ffmpeg_benchmark/tests/*
 branch = True
 source = ffmpeg_benchmark
 
+[coverage:report]
+show_missing = true
+exclude_lines =
+    noqa
+    NotImplemented
 [coverage:report]
 show_missing = true
 exclude_lines =


### PR DESCRIPTION
Changed install_requires to dependency_links, as the previous one does not seem to support urls.
Also changed some properties to use non deprecated syntax of _ instead of -